### PR TITLE
Add pom.xml to fix compiling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+    </parent>
+
+    <groupId>dev._2lstudios</groupId>
+    <artifactId>flamepaper-parent</artifactId>
+    <version>dev-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>FlamePaper-Parent</name>
+    <description>Parent project for all FlamePaper modules.</description>
+    <url>https://github.com/2lstudios-mc/FlamePaper</url>
+
+    <modules>
+        <module>FlamePaper-Server</module>
+        <module>FlamePaper-API</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>md_5-releases</id>
+            <url>https://repo.md-5.net/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+</project>


### PR DESCRIPTION
This must have been forgotten when adding back the developer tools. Compiling fails without it. It is pulled from an older branch before it was removed.